### PR TITLE
Fix keepalived config file error when there are no services

### DIFF
--- a/pkg/controller/keepalived.go
+++ b/pkg/controller/keepalived.go
@@ -82,6 +82,7 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	conf["useUnicast"] = k.useUnicast
 	conf["vrid"] = k.vrid
 	conf["proxyMode"] = k.proxyMode
+  conf["vipIsEmpty"] = len(k.vips) == 0
 
 	if glog.V(2) {
 		b, _ := json.Marshal(conf)

--- a/rootfs/keepalived.tmpl
+++ b/rootfs/keepalived.tmpl
@@ -5,6 +5,11 @@ global_defs {
   vrrp_iptables {{ .iptablesChain }}
 }
 
+
+#Check if the VIP list is empty
+{{ if not .vipIsEmpty }}
+
+
 {{ if .proxyMode }}
 vrrp_script chk_haproxy {
   script "/haproxy-check.sh"
@@ -65,4 +70,7 @@ virtual_server {{ $svc.IP }} {{ $svc.Port }} {
   {{ end }}
 }
 {{ end }}
+{{ end }}
+
+#End if vip list is empty
 {{ end }}


### PR DESCRIPTION
When my kubernetes there is no any service, I was getting the error below

```
Tue Sep  5 20:20:36 2017: Registering gratuitous ARP shared channel
Tue Sep  5 20:20:36 2017: Opening file '/etc/keepalived/keepalived.conf'.
Tue Sep  5 20:20:36 2017: (vips): No VIP specified; at least one is required
Tue Sep  5 20:20:37 2017: Stopped
Tue Sep  5 20:20:37 2017: Keepalived_vrrp exited with permanent error CONFIG. Terminating
Tue Sep  5 20:20:37 2017: Stopping
```
To fix it, I check if the VIPs list is empty then I only generate the virtual infrastructure if the list isn't empty.