### PR TITLE
add flag to set the host interface to use

### DIFF
--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -76,6 +76,9 @@ var (
 		`The keepalived VRID (Virtual Router Identifier, between 0 and 255 as per 
       RFC-5798), which must be different for every Virtual Router (ie. every 
       keepalived sets) running on the same network.`)
+        
+        iface = flags.String("iface", "", `network interface to listen on. If undefined, the nodes
+                 default interface will be used instead`)
 )
 
 func main() {
@@ -118,14 +121,13 @@ func main() {
 	if *proxyMode {
 		copyHaproxyCfg()
 	}
-
 	kubeClient, err := createApiserverClient(*apiserverHost, *kubeConfigFile)
 	if err != nil {
 		handleFatalInitError(err)
 	}
 
 	glog.Info("starting LVS configuration")
-	ipvsc := controller.NewIPVSController(kubeClient, *watchNamespace, *useUnicast, *configMapName, *vrid, *proxyMode)
+	ipvsc := controller.NewIPVSController(kubeClient, *watchNamespace, *useUnicast, *configMapName, *vrid, *proxyMode, *iface)
 
 	ipvsc.Start()
 }

--- a/pkg/controller/keepalived.go
+++ b/pkg/controller/keepalived.go
@@ -81,6 +81,7 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	conf["priority"] = k.priority
 	conf["useUnicast"] = k.useUnicast
 	conf["vrid"] = k.vrid
+        conf["iface"] = k.iface
 	conf["proxyMode"] = k.proxyMode
 	conf["vipIsEmpty"] = len(k.vips) == 0
 


### PR DESCRIPTION
This addresses issue #13 by allowing a user to specify an optional --iface flag that overrides the default NIC on the host.