### PR TITLE
Fix Helm 2.8.1 linting issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ chart/kube-keepalived-vip/Chart.yaml
 chart/kube-keepalived-vip/values.yaml
 # Ignore backup files
 *~
+.DS_Store
+

--- a/chart/kube-keepalived-vip/templates/daemonset.yaml
+++ b/chart/kube-keepalived-vip/templates/daemonset.yaml
@@ -15,18 +15,18 @@ spec:
       labels:
         app: {{ template "kube-keepalived-vip.name" . }}
         release: {{ .Release.Name }}
-        {{- if .Values.keepalived.podLabels }}
+        {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8}}
         {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-    {{- if .Values.keepalived.podAnnotations }}
+    {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8}}
     {{- end }}
       labels:
         app: {{ template "kube-keepalived-vip.name" . }}
         release: {{ .Release.Name }}
-        {{- if .Values.keepalived.podLabels }}
+        {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | indent 8}}
         {{- end }}
     spec:
@@ -61,7 +61,7 @@ spec:
                   fieldPath: metadata.namespace
           args:
             - --services-configmap={{ .Release.Namespace }}/{{ template "kube-keepalived-vip.fullname" . }}
-            - --use-unicast={{ if .Values.keepalived.useUnicast }}true{{ else }}false{{ end }}
+            - --use-unicast={{ .Values.keepalived.useUnicast }}
             - --vrid={{ .Values.keepalived.vrid }}
             - --logtostderr
 {{- if .Values.haproxy.enabled }}

--- a/chart/kube-keepalived-vip/values.yaml.tmpl
+++ b/chart/kube-keepalived-vip/values.yaml.tmpl
@@ -8,6 +8,9 @@ keepalived:
   # Content of the configuration ConfigMap supplied to kube-keepalive-vip
   config: {}
 
+  # Unicast uses the IP of the nodes instead of multicast. This is useful if running in cloud providers (like AWS).
+  useUnicast: false
+
   # VRRP virtual router ID, must be unique on a particular network segment (0-255)
   vrid: 179
 
@@ -27,6 +30,8 @@ haproxy:
   # Resource allocations for the HAProxy container
   resources: {}
   
+nameOverride: ""
+
 revisionHistoryLimit: 10
 
 # Update strategy (requires at least Kubernetes 1.6)


### PR DESCRIPTION
Fixes a few linting issues I ran into when running `make chart` with Helm 2.8.1.

- nameOverride wasn't specified in values.yaml
- daemonset.yaml using wrong/non-existing podLabels and podAnnotations
- keepalived.useUnicast wasn't specified in values.yaml
