### PR TITLE
Add fullnameOverride to chart

### DIFF
--- a/chart/kube-keepalived-vip/templates/_helpers.tpl
+++ b/chart/kube-keepalived-vip/templates/_helpers.tpl
@@ -6,11 +6,20 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "kube-keepalived-vip.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/chart/kube-keepalived-vip/templates/_helpers.tpl
+++ b/chart/kube-keepalived-vip/templates/_helpers.tpl
@@ -6,6 +6,7 @@ Expand the name of the chart.
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/chart/kube-keepalived-vip/values.yaml.tmpl
+++ b/chart/kube-keepalived-vip/values.yaml.tmpl
@@ -29,7 +29,8 @@ haproxy:
 
   # Resource allocations for the HAProxy container
   resources: {}
-  
+
+fullnameOverride: ""
 nameOverride: ""
 
 revisionHistoryLimit: 10


### PR DESCRIPTION
Add a `fullnameOverride` value to override `kube-keepalived-vip.fullname` function. This function is copied from the latest _helpers.tpl generated by `helm create`