### PR TITLE
Set maxconn globally

### DIFF
--- a/rootfs/haproxy.tmpl
+++ b/rootfs/haproxy.tmpl
@@ -1,6 +1,7 @@
 global
   ulimit-n      108035
   stats         socket /tmp/haproxy mode 600 level admin
+  maxconn	100000
 
 defaults
   maxconn       100000


### PR DESCRIPTION
Without setting maxconn in the global scope, the maximum connections are limited to 2k. This is too low and makes the setting under "defaults" meaningless.