### PR TITLE
Cleanup VIPs on startup

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:0.4.0
+FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
 
 COPY build.sh /build.sh
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
+FROM gcr.io/google-containers/debian-base-amd64:0.4.0
 
 COPY build.sh /build.sh
 

--- a/pkg/controller/keepalived.go
+++ b/pkg/controller/keepalived.go
@@ -69,6 +69,7 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	defer w.Close()
 
 	k.vips = getVIPs(svcs)
+	k.Cleanup()
 
 	conf := make(map[string]interface{})
 	conf["iptablesChain"] = iptablesChain
@@ -174,30 +175,34 @@ func (k *keepalived) Reload() error {
 	return nil
 }
 
+func (k *keepalived) Cleanup() {
+	glog.Infof("Cleanup: %s", k.vips)
+        for _, vip := range k.vips {
+                k.removeVIP(vip)
+        }
+
+        err := k.ipt.FlushChain(iptables.TableFilter, iptables.Chain(iptablesChain))
+        if err != nil {
+                glog.V(2).Infof("unexpected error flushing iptables chain %v: %v", err, iptablesChain)
+        }
+}
+
 // Stop stop keepalived process
 func (k *keepalived) Stop() {
-	for _, vip := range k.vips {
-		k.removeVIP(vip)
-	}
+	k.Cleanup()
 
-	err := k.ipt.FlushChain(iptables.TableFilter, iptables.Chain(iptablesChain))
-	if err != nil {
-		glog.V(2).Infof("unexpected error flushing iptables chain %v: %v", err, iptablesChain)
-	}
-
-	err = syscall.Kill(k.cmd.Process.Pid, syscall.SIGTERM)
+	err := syscall.Kill(k.cmd.Process.Pid, syscall.SIGTERM)
 	if err != nil {
 		glog.Errorf("error stopping keepalived: %v", err)
 	}
 }
 
-func (k *keepalived) removeVIP(vip string) error {
+func (k *keepalived) removeVIP(vip string) {
 	glog.Infof("removing configured VIP %v", vip)
 	out, err := k8sexec.New().Command("ip", "addr", "del", vip+"/32", "dev", k.iface).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("error reloading keepalived: %v\n%s", err, out)
+		glog.V(2).Infof("Error removing VIP %s: %v\n%s", vip, err, out)
 	}
-	return nil
 }
 
 func (k *keepalived) loadTemplates() error {

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -123,6 +123,7 @@ type ipvsControllerController struct {
 	keepalived *keepalived
 
 	configMapName string
+	configMapResourceVersion string
 
 	ruMD5 string
 
@@ -259,6 +260,12 @@ func (ipvsc *ipvsControllerController) sync(key interface{}) error {
 		return fmt.Errorf("unexpected error searching configmap %v: %v", ipvsc.configMapName, err)
 	}
 
+	if ipvsc.configMapResourceVersion == cfgMap.ObjectMeta.ResourceVersion {
+		glog.V(2).Infof("No change to %s ConfigMap", name)
+		return nil
+	}
+
+	ipvsc.configMapResourceVersion = cfgMap.ObjectMeta.ResourceVersion
 	svc := ipvsc.getServices(cfgMap)
 
 	err = ipvsc.keepalived.WriteCfg(svc)

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
+FROM gcr.io/google-containers/debian-base-amd64:0.4.0
 
 RUN clean-install \
   libssl1.1 \

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google-containers/debian-base-amd64:0.4.0
+FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
 
 RUN clean-install \
   libssl1.1 \
@@ -23,7 +23,7 @@ RUN clean-install \
   libxtables12 \
   libnfnetlink0 \
   libiptcdata0 \
-  libipset3 \
+  libipset11 \
   libipset-dev \
   libsnmp30 \
   kmod \


### PR DESCRIPTION
- Fixes #65 - Perform the same cleanup on startup that is currently done during shutdown to remove VIPs and flush iptables
- Avoid unnecessary apiserver calls if configmap hasn't changed
- Fixed docker build failing with libipset3 not found