### PR TITLE
Start kube-keepalived-vip via dumb-init

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -31,7 +31,8 @@ RUN clean-install \
   iproute2 \
   curl \
   ipvsadm \
-  bash
+  bash \
+  dumb-init
 
 ADD keepalived.tar.gz /
 
@@ -41,4 +42,4 @@ RUN mkdir -p /etc/keepalived && \
 
 COPY . /
 
-ENTRYPOINT ["/kube-keepalived-vip"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/kube-keepalived-vip"]


### PR DESCRIPTION
Best practice would be to put dumb-init into the ENTRYPOINT and kube-keepalived-vip into CMD. This commit puts both of them into ENTRYPOINT to be backwards compatible with current deployments which overwrite CMD.

I've tested the resulting image as a replacement for a deployment which has been running 0.29 up to now and have found no issues so far. Everything is as expected.

Fixes aledbf/kube-keepalived-vip#66

Signed-off-by: Lars Fenneberg <lf@elemental.net>