### PR TITLE
Add health check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ chart/kube-keepalived-vip/Chart.yaml
 chart/kube-keepalived-vip/values.yaml
 # Ignore backup files
 *~
+*.bak
 .DS_Store
 .idea/
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: push
 TAG = 0.30
 HAPROXY_TAG = 0.1
 # Helm uses SemVer2 versioning
-CHART_VERSION = 0.1.1
+CHART_VERSION = 0.2.0
 PREFIX = aledbf/kube-keepalived-vip
 BUILD_IMAGE = build-keepalived
 PKG = github.com/aledbf/kube-keepalived-vip
@@ -35,8 +35,9 @@ chart: chart/kube-keepalived-vip-$(CHART_VERSION).tgz
 .PHONY: chart-subst
 chart-subst: chart/kube-keepalived-vip/Chart.yaml.tmpl chart/kube-keepalived-vip/values.yaml.tmpl
 	for file in Chart.yaml values.yaml; do cp -f "chart/kube-keepalived-vip/$$file.tmpl" "chart/kube-keepalived-vip/$$file"; done
-	sed -i -e 's|%%TAG%%|$(TAG)|g' -e 's|%%HAPROXY_TAG%%|$(HAPROXY_TAG)|g' chart/kube-keepalived-vip/values.yaml
-	sed -i -e 's|%%CHART_VERSION%%|$(CHART_VERSION)|g' chart/kube-keepalived-vip/Chart.yaml
+	sed -i'.bak' -e 's|%%TAG%%|$(TAG)|g' -e 's|%%HAPROXY_TAG%%|$(HAPROXY_TAG)|g' chart/kube-keepalived-vip/values.yaml
+	sed -i'.bak' -e 's|%%CHART_VERSION%%|$(CHART_VERSION)|g' chart/kube-keepalived-vip/Chart.yaml
+	rm -f chart/kube-keepalived-vip/*.bak
 
 # Requires helm
 chart/kube-keepalived-vip-$(CHART_VERSION).tgz: chart-subst $(shell which helm) $(shell find chart/kube-keepalived-vip -type f)
@@ -74,3 +75,4 @@ dep-ensure:
 	dep ensure -v
 	dep prune -v
 	find vendor -name '*_test.go' -delete
+

--- a/chart/kube-keepalived-vip/templates/daemonset.yaml
+++ b/chart/kube-keepalived-vip/templates/daemonset.yaml
@@ -37,6 +37,12 @@ spec:
         - name: {{ template "kube-keepalived-vip.name" . }}-{{ .Values.keepalived.name }}
           image: "{{ .Values.keepalived.image.repository }}:{{ .Values.keepalived.image.tag }}"
           imagePullPolicy: "{{ .Values.keepalived.image.pullPolicy }}"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.httpPort }}
+            initialDelaySeconds: 15
+            timeoutSeconds: 3
           securityContext:
             privileged: true
           volumeMounts:
@@ -64,6 +70,7 @@ spec:
             - --use-unicast={{ .Values.keepalived.useUnicast }}
             - --vrid={{ .Values.keepalived.vrid }}
             - --logtostderr
+            - --http-port={{ .Values.httpPort }}
 {{- if .Values.haproxy.enabled }}
             - --proxy-protocol-mode=true
 {{- end }}

--- a/chart/kube-keepalived-vip/values.yaml.tmpl
+++ b/chart/kube-keepalived-vip/values.yaml.tmpl
@@ -30,6 +30,9 @@ haproxy:
   # Resource allocations for the HAProxy container
   resources: {}
 
+# Health check port
+httpPort: 8080
+
 fullnameOverride: ""
 nameOverride: ""
 

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -79,6 +79,8 @@ var (
 
 	iface = flags.String("iface", "", `network interface to listen on. If undefined, the nodes
                  default interface will be used instead`)
+
+	httpPort = flags.Int("http-port", 8080, `The HTTP port to use for health checks`)
 )
 
 func main() {
@@ -93,6 +95,10 @@ func main() {
 
 	if *configMapName == "" {
 		glog.Fatalf("Please specify --services-configmap")
+	}
+
+	if *httpPort < 0 || *httpPort > 65535 {
+		glog.Fatalf("Invalid HTTP port %d, only values between 0 and 65535 are allowed.", httpPort)
 	}
 
 	if *vrid < 0 || *vrid > 255 {
@@ -131,7 +137,7 @@ func main() {
 	}
 
 	glog.Info("starting LVS configuration")
-	ipvsc := controller.NewIPVSController(kubeClient, *watchNamespace, *useUnicast, *configMapName, *vrid, *proxyMode, *iface)
+	ipvsc := controller.NewIPVSController(kubeClient, *watchNamespace, *useUnicast, *configMapName, *vrid, *proxyMode, *iface, *httpPort)
 
 	ipvsc.Start()
 }

--- a/rootfs/keepalived-check.sh
+++ b/rootfs/keepalived-check.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+TYPE="$1"
+NAME="$2"
+STATE="$3"
+
+echo -n "${STATE}" > /var/run/keepalived.state
+exit 0
+

--- a/rootfs/keepalived.tmpl
+++ b/rootfs/keepalived.tmpl
@@ -40,6 +40,8 @@ vrrp_instance vips {
     {{ . }}{{ end }}
   }
 
+  notify /keepalived-check.sh
+
 {{ if .proxyMode }}
   # In proxy mode there is no need to create virtual servers
   track_script {

--- a/vip-daemonset-proxy.yaml
+++ b/vip-daemonset-proxy.yaml
@@ -24,6 +24,12 @@ spec:
               mountPath: /etc/haproxy
         - image: aledbf/kube-keepalived-vip:0.30
           name: kube-keepalived-vip
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 3
           securityContext:
             privileged: true
           volumeMounts:

--- a/vip-daemonset.yaml
+++ b/vip-daemonset.yaml
@@ -12,7 +12,13 @@ spec:
       containers:
         - image: aledbf/kube-keepalived-vip:0.30
           name: kube-keepalived-vip
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 15
+            timeoutSeconds: 3
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
Fixes #54 by adding a /health HTTP endpoint

- Add a keepalived notify script to be aware of state transitions
- Add livenessProbe to Helm chart and standalone daemonsets. I didn't add a readinessProbe since kube-keepalived-vip has no services.
- Add a `--http-port` command line parameter with default of 8080 in case the default conflicts with other ports used on hostNetwork. Named it http-port instead of health-check-port in case other HTTP endpoints are needed in the future.
- Health check logic ensures that all VIPs are present in `ip addr show` on MASTER instance and that no VIPs are present on BACKUP/FAULT instances.
- Fix `make chart` on Mac OS X by using sed with backup extension

Test by `ip addr del ip dev eth0` and `ip addr add dev eth0`