### PR TITLE
add notify script via environment variable

### DIFF
--- a/pkg/controller/keepalived.go
+++ b/pkg/controller/keepalived.go
@@ -64,6 +64,7 @@ type keepalived struct {
 	ipt            iptables.Interface
 	vrid           int
 	proxyMode      bool
+	notify         string
 }
 
 // WriteCfg creates a new keepalived configuration file.
@@ -91,6 +92,7 @@ func (k *keepalived) WriteCfg(svcs []vip) error {
 	conf["iface"] = k.iface
 	conf["proxyMode"] = k.proxyMode
 	conf["vipIsEmpty"] = len(k.vips) == 0
+	conf["notify"] = k.notify
 
 	if glog.V(2) {
 		b, _ := json.Marshal(conf)

--- a/pkg/controller/main.go
+++ b/pkg/controller/main.go
@@ -386,6 +386,8 @@ func NewIPVSController(kubeClient *kubernetes.Clientset, namespace string, useUn
 	}
 	neighbors := getNodeNeighbors(nodeInfo, clusterNodes)
 
+	notify := os.Getenv("KEEPALIVED_NOTIFY")
+
 	if iface == "" {
 		iface = nodeInfo.iface
 		glog.Info("No interface was provided, proceeding with the node's default: ", iface)
@@ -405,6 +407,7 @@ func NewIPVSController(kubeClient *kubernetes.Clientset, namespace string, useUn
 		ipt:        iptInterface,
 		vrid:       vrid,
 		proxyMode:  proxyMode,
+		notify:     notify,
 	}
 
 	ipvsc.syncQueue = task.NewTaskQueue(ipvsc.sync)

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -32,6 +32,7 @@ RUN clean-install \
   curl \
   ipvsadm \
   bash \
+  jq \
   dumb-init
 
 ADD keepalived.tar.gz /

--- a/rootfs/keepalived.tmpl
+++ b/rootfs/keepalived.tmpl
@@ -29,6 +29,8 @@ vrrp_instance vips {
     {{ $iface }}
   }
 
+  {{ if .notify }} notify {{ .notify }} {{ end }}
+
   {{ if .useUnicast }}
   unicast_src_ip {{ .myIP }}
   unicast_peer { {{ range .nodes }}
@@ -53,8 +55,8 @@ vrrp_instance vips {
 
 {{ if not .proxyMode }}
 {{ range $i, $svc := .svcs }}
-{{ if eq $svc.LVSMethod "VIP" }} 
-# VIP Service with no pods: {{ $svc.IP }} 
+{{ if eq $svc.LVSMethod "VIP" }}
+# VIP Service with no pods: {{ $svc.IP }}
 {{ else }}
 # Service: {{ $svc.Name }}
 virtual_server {{ $svc.IP }} {{ $svc.Port }} {


### PR DESCRIPTION
keepalived supports executing `notify` scripts on events, which come in handy when having to react to events, e.g. when performing a failover, and trigger any update. In this specific case it is needed for Hetzner Failover/Floating IPs to perform a JSON API call to the Hetzner API and notify them about the changed IP assignment.

As mentioned in a comment in @cornelius-keller's PR https://github.com/kubernetes/contrib/pull/2912, this repository here is more maintained and, therefore, I have applied the necessary changes and hopefully this can get merged. :)