### PR TITLE
Extended configMap

### DIFF
--- a/pkg/controller/keepalived_test.go
+++ b/pkg/controller/keepalived_test.go
@@ -1,0 +1,99 @@
+package controller
+
+import (
+	"os"
+	"path"
+	"runtime"
+	"testing"
+
+	utildbus "k8s.io/kubernetes/pkg/util/dbus"
+	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	utilexec "k8s.io/utils/exec"
+)
+
+func TestKeepalived_GenerateCfg(t *testing.T) {
+	keepalivedConfigWant := "\n\n\nglobal_defs {\n  vrrp_version 3\n  vrrp_iptables KUBE-KEEPALIVED-VIP\n}\n\n\n#Check " +
+		"if the VIP list is empty\n\n\n\n\n\n\nvrrp_instance vips {\n  state BACKUP\n  interface eth0\n  virtual_router_id " +
+		"100\n  priority 101\n  nopreempt\n  advert_int 1\n\n  track_interface {\n    eth0\n  }\n\n  \n\n  virtual_ipaddress " +
+		"{ \n    192.168.0.1\n  }\n\n  notify /keepalived-check.sh\n\n\n\n}\n\nvrrp_instance vips {\n  state BACKUP\n  " +
+		"interface eth1\n  virtual_router_id 101\n  priority 101\n  nopreempt\n  advert_int 1\n\n  track_interface {\n  " +
+		"  eth1\n  }\n\n  \n\n  virtual_ipaddress { \n    192.168.1.1\n  }\n\n  notify /keepalived-check.sh\n\n\n\n}" +
+		"\n\n\n\n\n\n# Service: service-1\nvirtual_server 192.168.0.1 10001 {\n  delay_loop 5\n  lvs_sched wlc\n  lvs_method " +
+		"NAT\n  persistence_timeout 1800\n  protocol TCP\n\n  \n  real_server 10.0.0.1 1001 {\n    weight 1\n    TCP_CHECK " +
+		"{\n      connect_port 1001\n      connect_timeout 3\n    }\n  }\n  \n}\n\n\n\n# Service: service-2\nvirtual_server " +
+		"192.168.0.1 10002 {\n  delay_loop 5\n  lvs_sched wlc\n  lvs_method NAT\n  persistence_timeout 1800\n  protocol " +
+		"TCP\n\n  \n  real_server 10.0.0.1 1002 {\n    weight 1\n    TCP_CHECK {\n      connect_port 1002\n      " +
+		"connect_timeout 3\n    }\n  }\n  \n}\n\n\n\n# Service: service-3\nvirtual_server 192.168.1.1 10001 {\n  " +
+		"delay_loop 5\n  lvs_sched wlc\n  lvs_method NAT\n  persistence_timeout 1800\n  protocol TCP\n\n  \n  real_server " +
+		"10.0.1.1 1001 {\n    weight 1\n    TCP_CHECK {\n      connect_port 1001\n      connect_timeout 3\n    }\n  }\n  \n}" +
+		"\n\n\n\n#End if vip list is empty\n\n\n"
+
+	svcs := []vip{
+		{
+			Name:      "service-1",
+			IP:        "192.168.0.1",
+			Port:      10001,
+			Protocol:  "TCP",
+			LVSMethod: "NAT",
+			iface:     "eth0",
+			Backends: []service{
+				{IP: "10.0.0.1", Port: 1001},
+			},
+		},
+		{
+			Name:      "service-2",
+			IP:        "192.168.0.1",
+			Port:      10002,
+			Protocol:  "TCP",
+			LVSMethod: "NAT",
+			iface:     "eth0",
+			Backends: []service{
+				{IP: "10.0.0.1", Port: 1002},
+			},
+		},
+		{
+			Name:      "service-3",
+			IP:        "192.168.1.1",
+			Port:      10001,
+			Protocol:  "TCP",
+			LVSMethod: "NAT",
+			iface:     "eth1",
+			Backends: []service{
+				{IP: "10.0.1.1", Port: 1001},
+			},
+		},
+	}
+
+	execer := utilexec.New()
+	dbus := utildbus.New()
+	iptInterface := utiliptables.New(execer, dbus, utiliptables.ProtocolIpv4)
+
+	k := &keepalived{
+		iface:      "ethDefault",
+		ip:         "10.1.1.1",
+		netmask:    24,
+		nodes:      []string{"10.1.1.1", "10.1.1.2"},
+		neighbors:  []string{"10.1.1.2"},
+		priority:   101,
+		useUnicast: false,
+		ipt:        iptInterface,
+		vrid:       100,
+		proxyMode:  false,
+	}
+
+	_, filename, _, _ := runtime.Caller(0)
+	err := os.Chdir(path.Dir(filename) + "/../../rootfs")
+
+	if err := k.loadTemplates(); err != nil {
+		t.Fatalf("GenerateCfg returned error: %v", err)
+	}
+
+	keepalivedConfig, _, err := k.GenerateCfg(svcs)
+	if err != nil {
+		t.Fatalf("GenerateCfg returned error: %v", err)
+	}
+
+	if keepalivedConfigWant != string(keepalivedConfig) {
+		t.Errorf("Invalid config generated: \n === want === \n%q\n=== got ===\n%q", keepalivedConfigWant, keepalivedConfig)
+	}
+}

--- a/pkg/controller/utils.go
+++ b/pkg/controller/utils.go
@@ -253,3 +253,14 @@ func (ns nodeSelector) String() string {
 func parseNodeSelector(data map[string]string) string {
 	return nodeSelector(data).String()
 }
+
+func parseAddress(address string) (ip, iface string, err error) {
+	re := regexp.MustCompile(`^(?:\w+-)?([a-f\d.:]+)(?:@(.+))?$`)
+	matches := re.FindStringSubmatch(address)
+
+	if matches == nil {
+		return "", "", fmt.Errorf("invalid address tring: %q", address)
+	}
+
+	return matches[1], matches[2], nil
+}

--- a/pkg/controller/utils_test.go
+++ b/pkg/controller/utils_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -53,6 +55,58 @@ func TestParseNsSvcLVS(t *testing.T) {
 
 		if tc.ForwardMethod != lvs {
 			t.Errorf("%s: expected %v but returned %v - input %v", k, tc.ForwardMethod, lvs, tc.Input)
+		}
+	}
+}
+
+func TestParseAddress(t *testing.T) {
+	table := []struct {
+		address           string
+		wantIp, wantIface string
+		wantErr           error
+	}{
+		{
+			"1-192.168.0.1@eth0",
+			"192.168.0.1",
+			"eth0",
+			nil,
+		},
+		{
+			"1-2001:db8:85a3::8a2e:370:7334@eth0",
+			"2001:db8:85a3::8a2e:370:7334",
+			"eth0",
+			nil,
+		},
+		{
+			"192.168.0.1@eth0",
+			"192.168.0.1",
+			"eth0",
+			nil,
+		},
+		{
+			"192.168.0.1",
+			"192.168.0.1",
+			"",
+			nil,
+		},
+		{
+			"eth0",
+			"",
+			"",
+			errors.New(`invalid address tring: "eth0"`),
+		},
+	}
+
+	for i, v := range table {
+		ip, iface, err := parseAddress(v.address)
+		if ip != v.wantIp {
+			t.Errorf("Unexpected ip in %d: want: %q, got: %q", i, v.wantIp, ip)
+		}
+		if iface != v.wantIface {
+			t.Errorf("Unexpected interface name in %d: want: %q, got: %q", i, v.wantIface, iface)
+		}
+		if fmt.Sprintf("%s", v.wantErr) != fmt.Sprintf("%s", err) {
+			t.Errorf("Unexpected error in %d: want: %q, got: %q", i, v.wantErr, err)
 		}
 	}
 }

--- a/rootfs/keepalived.tmpl
+++ b/rootfs/keepalived.tmpl
@@ -1,4 +1,5 @@
-{{ $iface := .iface }}{{ $netmask := .netmask }}
+{{ $netmask := .netmask }}
+{{ $cfg := . }}
 
 global_defs {
   vrrp_version 3
@@ -17,32 +18,33 @@ vrrp_script chk_haproxy {
 }
 {{ end }}
 
+{{ range $i, $iface := .ifaces }}
 vrrp_instance vips {
   state BACKUP
-  interface {{ $iface }}
-  virtual_router_id {{ .vrid }}
-  priority {{ .priority }}
+  interface {{ $iface.Name }}
+  virtual_router_id {{ $iface.Vrid }}
+  priority {{ $cfg.priority }}
   nopreempt
   advert_int 1
 
   track_interface {
-    {{ $iface }}
+    {{ $iface.Name }}
   }
 
-  {{ if .useUnicast }}
-  unicast_src_ip {{ .myIP }}
-  unicast_peer { {{ range .nodes }}
+  {{ if $cfg.useUnicast }}
+  unicast_src_ip {{ $cfg.myIP }}
+  unicast_peer { {{ range $cfg.nodes }}
     {{ . }}{{ end }}
   }
   {{ end }}
 
-  virtual_ipaddress { {{ range .vips }}
+  virtual_ipaddress { {{ range $iface.Ips }}
     {{ . }}{{ end }}
   }
 
   notify /keepalived-check.sh
 
-{{ if .proxyMode }}
+{{ if $cfg.proxyMode }}
   # In proxy mode there is no need to create virtual servers
   track_script {
     chk_haproxy weight 1
@@ -50,6 +52,7 @@ vrrp_instance vips {
 {{ end }}
 
 }
+{{ end }}
 
 {{ if not .proxyMode }}
 {{ range $i, $svc := .svcs }}


### PR DESCRIPTION
In our usecase we met several problems:
1. we have several services on the same IP, but it is impossible to specify them in the keepalived-vip configmap due to CM key is justs IP
2. services defined on several different interfaces, so we need to run several instances of keepalived-vip, one per interface

To solve this problems, we've extended configmap semantics: configmap key now is `[OPTIONAL_INDEX-]IP_ADDRESS[@OPTIONAL_INTERFACE]`, e.g.: `01-10.0.0.1@eth0` or `01-10.0.0.1` or `10.0.0.1@eth0` or just `10.0.0.1`. It allows to specify several services on single IPs and explicitly specify interface name. If interface is not specified in configmap, it uses interface specified via `--iface` flag
