### PR TITLE
Don't remove VIPs on reload

### DIFF
--- a/pkg/controller/keepalived.go
+++ b/pkg/controller/keepalived.go
@@ -171,7 +171,6 @@ func (k *keepalived) Reload() error {
 		time.Sleep(time.Second)
 	}
 
-	k.Cleanup()
 	glog.Info("reloading keepalived")
 	err := syscall.Kill(k.cmd.Process.Pid, syscall.SIGHUP)
 	if err != nil {


### PR DESCRIPTION
Fixes #96

`Cleanup()` in `Reload()` was added to fix duplicate VIPs. The health check now properly detects if instance is in backup state and contains a VIP, trigger a shutdown, which will remove all VIPs so this is no longer needed.