### PR TITLE
add script user into keepalived.conf

### DIFF
--- a/rootfs/keepalived.tmpl
+++ b/rootfs/keepalived.tmpl
@@ -3,6 +3,10 @@
 global_defs {
   vrrp_version 3
   vrrp_iptables {{ .iptablesChain }}
+  #get rid of warning:  default user 'keepalived_script' for script execution does not exist - please create
+  script_user root
+  enable_script_security
+
 }
 
 


### PR DESCRIPTION
[Reason]
to get rid of warning in logs
`WARNING - default user 'keepalived_script' for script execution does not exist - please create.`
because this container is running as root, so specific it explicitly.
[Test]
rebuild the image the deploy/run it. 