### PR TITLE
Cleanup() after stopping keepalived process

### DIFF
--- a/pkg/controller/keepalived.go
+++ b/pkg/controller/keepalived.go
@@ -261,12 +261,11 @@ func (k *keepalived) Cleanup() {
 
 // Stop stop keepalived process
 func (k *keepalived) Stop() {
-	k.Cleanup()
-
 	err := syscall.Kill(k.cmd.Process.Pid, syscall.SIGTERM)
 	if err != nil {
 		glog.Errorf("error stopping keepalived: %v", err)
 	}
+	k.Cleanup()
 }
 
 func (k *keepalived) removeVIP(vip string) {


### PR DESCRIPTION
Rational:
Otherwise, when pods were terminating, the backup keepalived may switched to master role, and bind VIP to its NIC.
At the end,  pods are all disappeared, but the VIP still exists on the backup node.