### PR TITLE
Disable net/ipv4/vs/conn_reuse_mode to improve IPVS performance

### DIFF
--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -70,6 +70,11 @@ var (
 		"net/ipv4/ip_nonlocal_bind": 1,
 		// enable connection tracking for LVS connections
 		"net/ipv4/vs/conntrack": 1,
+		//to resolve the ipvs performance issue:
+		// reference: https://github.com/kubernetes/kubernetes/issues/70747
+		//            https://github.com/cloudnativelabs/kube-router/issues/544
+		// And kube-proxy running in IPVS mode also sets conn_reuse_mode to 0.
+		"net/ipv4/vs/conn_reuse_mode": 0,
 	}
 
 	vrid = flags.Int("vrid", 50,


### PR DESCRIPTION
This is to address the performance issue.
when stressing the VIP:port  , the response latency will become 1 second long after a while, and looping. 
below is the jMeter response time diagram, you will see the response time become 1s and last ~30 s. (using `ab` to stress will see the same thing)
![image](https://user-images.githubusercontent.com/14049268/66795954-c1caa100-ef38-11e9-93a3-b7a703767c3f.png)

This is a known situation in kubernetes community, resolution is to disabling `net/ipv4/vs/conn_reuse_mode`, which kube-proxy does the same way in IPVS mode.

reference: 
https://github.com/kubernetes/kubernetes/issues/70747
https://github.com/cloudnativelabs/kube-router/issues/544
