### PR TITLE
Helm chart: adjust API version of DaemonSet for compatibility with K8s 1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: push
 TAG = 0.35
 HAPROXY_TAG = 0.1
 # Helm uses SemVer2 versioning
-CHART_VERSION = 0.2.0
+CHART_VERSION = 1.0.0
 PREFIX = aledbf/kube-keepalived-vip
 BUILD_IMAGE = build-keepalived
 PKG = github.com/aledbf/kube-keepalived-vip

--- a/chart/kube-keepalived-vip/templates/daemonset.yaml
+++ b/chart/kube-keepalived-vip/templates/daemonset.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -10,6 +10,13 @@ metadata:
   name: {{ template "kube-keepalived-vip.fullname" . }}
 spec:
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ template "kube-keepalived-vip.name" . }}
+      release: {{ .Release.Name }}
+      {{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 6}}
+      {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION

* Starting with Kubernetes 1.16 the API version extensions/v1beta1 is no
  longer support by default and will be removed in 1.18.  See
  https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md#deprecations-and-removals.

* apps/v1/DaemonSet makes the pod selector mandatory.

* The chart's major version is increased because this change breaks
  deployments on Kubernetes versions older than 1.9 as they don't support
  apps/v1/DaemonSet.  Kubernetes 1.9 was released in December 2017.