### PR TITLE
Update keepalived to v2.0.19

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,8 +16,8 @@ FROM quay.io/kubernetes-ingress-controller/debian-base-amd64:0.1
 
 COPY build.sh /build.sh
 
-ENV VERSION 2.0.16
-ENV SHA256 ce754f637f98db4595354ba9769bf9e62126d4cf1ff077334915722177c8c4bc
+ENV VERSION 2.0.19
+ENV SHA256 75818c1a62ebf4514c652fdd828184765b11b718f72903d14ab25bd53e4f86a5
 
 RUN clean-install bash
 


### PR DESCRIPTION
There is a bug in v2.0.16 of keepalived which is segfaulting when vsg is configured. The fixing commit: https://github.com/acassen/keepalived/commit/50382b81c7ae8720b97073e3e919de12171b1b45 this resolves issue when we upgrade ingress controller and the downloading of new images takes to long time.