### PR TITLE
Pod labeler

### DIFF
--- a/chart/kube-keepalived-vip/templates/cluster-role.yaml
+++ b/chart/kube-keepalived-vip/templates/cluster-role.yaml
@@ -18,4 +18,8 @@ rules:
   - services
   - configmaps
   verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["update"]
 {{- end -}}

--- a/pkg/controller/keepalived.go
+++ b/pkg/controller/keepalived.go
@@ -195,17 +195,18 @@ func (k *keepalived) IsRunning() bool {
 	return true
 }
 
-func isMaster() bool {
+func (k *keepalived) isMaster() bool {
 	b, err := ioutil.ReadFile(keepalivedState)
 	if err != nil {
-		return err
-	}
-
-	if strings.Contains(state, "MASTER") {
-		return true
-	} else {
 		return false
 	}
+
+	state := strings.TrimSpace(string(b))
+	if strings.Contains(state, "BACKUP") {
+		return false
+	} 
+
+	return true
 }
 
 // Whether keepalived child process is currently running and VIPs are assigned

--- a/pkg/controller/keepalived.go
+++ b/pkg/controller/keepalived.go
@@ -195,6 +195,19 @@ func (k *keepalived) IsRunning() bool {
 	return true
 }
 
+func isMaster() bool {
+	b, err := ioutil.ReadFile(keepalivedState)
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(state, "MASTER") {
+		return true
+	} else {
+		return false
+	}
+}
+
 // Whether keepalived child process is currently running and VIPs are assigned
 func (k *keepalived) Healthy() error {
 	if !k.IsRunning() {

--- a/pkg/k8s/main.go
+++ b/pkg/k8s/main.go
@@ -81,17 +81,17 @@ func GetPodDetails(kubeClient clientset.Interface) (*PodInfo, error) {
 	}, nil
 }
 
-func SetPodLabels(kubeClient clientset.Interface,  labels map[string]string) nil, error{
+func SetPodLabels(kubeClient clientset.Interface,  labels map[string]string) (error) {
 	podName := os.Getenv("POD_NAME")
 	podNs := os.Getenv("POD_NAMESPACE")
 
 	if podName == "" || podNs == "" {
-		return nil, fmt.Errorf("unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable")
+		return fmt.Errorf("unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable")
 	}
 
 	pod, _ := kubeClient.CoreV1().Pods(podNs).Get(podName, meta_v1.GetOptions{})
 	if pod == nil {
-		return nil, fmt.Errorf("unable to get POD information")
+		return fmt.Errorf("unable to get POD information")
 	}
 
 	for k,v := range labels {
@@ -100,7 +100,9 @@ func SetPodLabels(kubeClient clientset.Interface,  labels map[string]string) nil
 
 	podUpdate, _ := kubeClient.CoreV1().Pods(podNs).Update(pod)
 	if podUpdate == nil {
-		return nil, fmt.Errorf("unable to set labels on pod")
+		return fmt.Errorf("unable to set labels on pod")
 	}
+
+	return nil
 
 }

--- a/pkg/k8s/main.go
+++ b/pkg/k8s/main.go
@@ -80,3 +80,27 @@ func GetPodDetails(kubeClient clientset.Interface) (*PodInfo, error) {
 		Labels:    pod.GetLabels(),
 	}, nil
 }
+
+func SetPodLabels(kubeClient clientset.Interface,  labels map[string]string) {
+	podName := os.Getenv("POD_NAME")
+	podNs := os.Getenv("POD_NAMESPACE")
+
+	if podName == "" || podNs == "" {
+		return nil, fmt.Errorf("unable to get POD information (missing POD_NAME or POD_NAMESPACE environment variable")
+	}
+
+	pod, _ := kubeClient.CoreV1().Pods(podNs).Get(podName, meta_v1.GetOptions{})
+	if pod == nil {
+		return nil, fmt.Errorf("unable to get POD information")
+	}
+
+	for k,v := range labels {
+		pod.ObjectMeta.Labels[k] = v
+	}
+
+	podUpdate, _ := kubeClient.CoreV1().Pods(podNs).Update(pod)
+	if podUpdate == nil {
+		return nil, fmt.Errorf("unable to set labels on pod")
+	}
+
+}

--- a/pkg/k8s/main.go
+++ b/pkg/k8s/main.go
@@ -81,7 +81,7 @@ func GetPodDetails(kubeClient clientset.Interface) (*PodInfo, error) {
 	}, nil
 }
 
-func SetPodLabels(kubeClient clientset.Interface,  labels map[string]string) {
+func SetPodLabels(kubeClient clientset.Interface,  labels map[string]string) nil, error{
 	podName := os.Getenv("POD_NAME")
 	podNs := os.Getenv("POD_NAMESPACE")
 


### PR DESCRIPTION
A while back I wrote a sidecar that would patch the pod with either vip-holder true or vip-holder false depending on the keepalived state. I decided to write the code into the upstream project as part of the /health endpoint. 